### PR TITLE
Ajusta uso de constantes de paginación en el hook

### DIFF
--- a/frontend/hooks/use-pagination.ts
+++ b/frontend/hooks/use-pagination.ts
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react'
-import { PAGINATION } from '@/lib/constants'
+import { PAGINACION } from '@/lib/constants'
 
 interface UsePaginationOptions {
   totalItems: number
@@ -10,7 +10,7 @@ interface UsePaginationOptions {
 export function usePagination({
   totalItems,
   initialPage = 1,
-  initialPageSize = PAGINATION.DEFAULT_PAGE_SIZE
+  initialPageSize = PAGINACION.TAMAÑO_PAGINA_POR_DEFECTO
 }: UsePaginationOptions) {
   const [currentPage, setCurrentPage] = useState(initialPage)
   const [pageSize, setPageSize] = useState(initialPageSize)


### PR DESCRIPTION
## Summary
- replace the pagination constants import in the pagination hook with the localized `PAGINACION`
- update the default page size reference to the new constant name

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d97dedcbb483249729c0b91b93db05