### PR TITLE
Prevent querying available socios when no temporada selected

### DIFF
--- a/frontend/components/association/add-member-dialog.tsx
+++ b/frontend/components/association/add-member-dialog.tsx
@@ -11,15 +11,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import {
-  Search,
-  UserPlus,
-  Mail,
-  Phone,
-  Plus,
-  ArrowRight,
-  ArrowLeft,
-} from "lucide-react";
+import { Search, UserPlus, Plus, ArrowRight, ArrowLeft } from "lucide-react";
 import { SocioWithFoto } from "@/lib/types";
 import { useSociosDisponiblesTemporada } from "@/hooks/api/temporadas/useSociosDisponiblesTemporada";
 
@@ -42,7 +34,6 @@ export function AddMemberDialog({
   const {
     data: socios,
     isLoading,
-    searchTerm: currentSearchTerm,
     setSearch: setSociosSearchTerm,
     nextPage,
     prevPage,
@@ -50,13 +41,16 @@ export function AddMemberDialog({
     page,
     totalPages,
     total,
+    enabled: sociosQueryEnabled,
   } = useSociosDisponiblesTemporada(temporadaId);
 
   const sociosData = socios || [];
 
   const handleSearchChange = (value: string) => {
     setSearchTerm(value);
-    setSociosSearchTerm(value);
+    if (sociosQueryEnabled) {
+      setSociosSearchTerm(value);
+    }
   };
 
   const handleAddMember = (socioId: string) => {
@@ -96,12 +90,19 @@ export function AddMemberDialog({
               value={searchTerm}
               onChange={(e) => handleSearchChange(e.target.value)}
               className="pl-10"
+              disabled={!sociosQueryEnabled}
             />
           </div>
 
           {/* Members List */}
           <div className="flex-1 overflow-y-auto">
-            {isLoading && socios.length === 0 ? (
+            {!sociosQueryEnabled ? (
+              <div className="p-4 text-center">
+                <p className="text-sm text-muted-foreground">
+                  Selecciona una temporada para buscar socios disponibles.
+                </p>
+              </div>
+            ) : isLoading && socios.length === 0 ? (
               <div className="p-4 text-center">
                 <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto"></div>
                 <p className="mt-2 text-sm text-muted-foreground">
@@ -187,7 +188,7 @@ export function AddMemberDialog({
           </div>
 
           {/* Pagination */}
-          {totalPages > 1 && socios.length > 0 && (
+          {sociosQueryEnabled && totalPages > 1 && socios.length > 0 && (
             <div className="p-4 border-t">
               <div className="flex flex-col text-center items-center justify-between">
                 <p className="text-sm text-muted-foreground mb-4">

--- a/frontend/hooks/api/common/usePaginatedSearchQuery.ts
+++ b/frontend/hooks/api/common/usePaginatedSearchQuery.ts
@@ -15,12 +15,14 @@ interface UsePaginatedSearchQueryOptions<T> {
   queryKey: string;
   url: string;
   initialLimit?: number;
+  enabled?: boolean;
 }
 
 export function usePaginatedSearchQuery<T>({
   queryKey,
   url,
   initialLimit = 10,
+  enabled = true,
 }: UsePaginatedSearchQueryOptions<T>) {
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(initialLimit);
@@ -56,6 +58,7 @@ export function usePaginatedSearchQuery<T>({
     },
     staleTime: STALE_TIME,
     placeholderData: (previousData) => previousData,
+    enabled,
   });
 
   const totalPages = Math.ceil((query.data?.total || 0) / limit);

--- a/frontend/hooks/api/temporadas/useSociosDisponiblesTemporada.tsx
+++ b/frontend/hooks/api/temporadas/useSociosDisponiblesTemporada.tsx
@@ -4,9 +4,17 @@ import { usePaginatedSearchQuery } from "../common/usePaginatedSearchQuery";
 import { SocioWithFoto } from "@/lib/types";
 
 export const useSociosDisponiblesTemporada = (temporadaId: string | null) => {
-  return usePaginatedSearchQuery<SocioWithFoto>({
-    queryKey: `socios`,
+  const enabled = Boolean(temporadaId);
+
+  const query = usePaginatedSearchQuery<SocioWithFoto>({
+    queryKey: temporadaId ? `socios-${temporadaId}` : "socios",
     url: temporadaId ? `/temporadas/${temporadaId}/socios-disponibles` : "",
     initialLimit: 10,
+    enabled,
   });
+
+  return {
+    ...query,
+    enabled,
+  };
 };


### PR DESCRIPTION
## Summary
- add an optional `enabled` flag to the shared paginated search hook so queries can be disabled
- stop requesting available socios when no temporada is selected and expose the enabled state to consumers
- disable the add-member dialog search UI and show guidance until a temporada is chosen

## Testing
- npm run lint *(fails: interactive migration prompt from `next lint`)*

------
https://chatgpt.com/codex/tasks/task_e_68d97dee91ac83249be63661bd0601a8