### PR TITLE
Adjust socios disponibles hook to temporadas endpoint

### DIFF
--- a/frontend/hooks/api/socios/useSociosDisponiblesInfinite.tsx
+++ b/frontend/hooks/api/socios/useSociosDisponiblesInfinite.tsx
@@ -10,15 +10,19 @@ interface SociosDisponiblesParams {
 }
 
 interface SociosDisponiblesResponse {
-  socios: SocioWithFoto[];
-  paginacion: {
-    paginaActual: number;
-    totalPaginas: number;
-    totalElementos: number;
-    elementosPorPagina: number;
-    tieneSiguientePagina: boolean;
-    tieneAnteriorPagina: boolean;
-  };
+  data: SocioWithFoto[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+interface SociosDisponiblesPagination {
+  page: number;
+  totalPages: number;
+  total: number;
+  limit: number;
+  hasNextPage: boolean;
 }
 
 export const useSociosDisponiblesInfinite = ({ 
@@ -31,50 +35,54 @@ export const useSociosDisponiblesInfinite = ({
     queryFn: async ({ pageParam = 1 }: { pageParam: unknown }) => {
       const page = pageParam as number;
       if (!temporadaId) {
-        return { 
-          socios: [], 
-          paginacion: { 
-            paginaActual: 1, 
-            totalPaginas: 0, 
-            totalElementos: 0, 
-            elementosPorPagina: limit, 
-            tieneSiguientePagina: false, 
-            tieneAnteriorPagina: false 
-          } 
+        return {
+          data: [],
+          total: 0,
+          page: 1,
+          limit,
+          totalPages: 0
         };
       }
 
       const response = await apiClient.get<SociosDisponiblesResponse>(
-        `/socios/disponibles-para-temporada/${temporadaId}`,
+        `/temporadas/${temporadaId}/socios-disponibles`,
         {
           params: {
-            pagina: page,
-            limite: limit,
-            ...(search && { busqueda: search })
+            page,
+            limit,
+            ...(search && { search })
           }
         }
       );
       return response.data;
     },
     enabled: !!temporadaId,
-    getNextPageParam: (lastPage) => {
-      if (lastPage.paginacion.tieneSiguientePagina) {
-        return lastPage.paginacion.paginaActual + 1;
-      }
-      return undefined;
-    },
+    getNextPageParam: (lastPage) =>
+      lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
     initialPageParam: 1,
   });
 
   // Flatten all pages into a single array
   const allSocios = useMemo(() => {
-    return query.data?.pages.flatMap((page: SociosDisponiblesResponse) => page.socios) || [];
+    return query.data?.pages.flatMap((page: SociosDisponiblesResponse) => page.data) || [];
   }, [query.data]);
 
   // Get pagination info from the last page
   const paginationInfo = useMemo(() => {
-    const lastPage = query.data?.pages[query.data.pages.length - 1] as SociosDisponiblesResponse | undefined;
-    return lastPage?.paginacion || null;
+    if (!query.data?.pages.length) {
+      return null;
+    }
+
+    const lastPage = query.data.pages[query.data.pages.length - 1] as SociosDisponiblesResponse;
+    const pagination: SociosDisponiblesPagination = {
+      page: lastPage.page,
+      totalPages: lastPage.totalPages,
+      total: lastPage.total,
+      limit: lastPage.limit,
+      hasNextPage: lastPage.page < lastPage.totalPages,
+    };
+
+    return pagination;
   }, [query.data]);
 
   return {

--- a/frontend/manual-tests.md
+++ b/frontend/manual-tests.md
@@ -1,0 +1,22 @@
+# Pruebas manuales - Carga incremental de socios disponibles
+
+## Objetivo
+Verificar que el listado incremental de socios disponibles para una temporada se alimente desde la API `/temporadas/:id/socios-disponibles` y cargue páginas adicionales al solicitar más resultados.
+
+## Pre-requisitos
+- Backend y frontend ejecutándose con datos semilla que incluyan socios y temporadas.
+- Un usuario autenticado con permisos para gestionar temporadas.
+- Identificar el `ID` de una temporada que tenga más socios disponibles que el límite configurado (por defecto 10).
+
+## Pasos
+1. Iniciar sesión en la aplicación y navegar al flujo de gestión de socios de una temporada.
+2. Abrir el selector o listado que consuma el hook `useSociosDisponiblesInfinite`.
+3. Confirmar en las herramientas de red del navegador que la primera petición apunta a `GET /temporadas/{ID}/socios-disponibles?page=1&limit=10` (ajustado según filtros).
+4. Aplicar un filtro de búsqueda opcional y validar que la petición incluya el parámetro `search` con el término ingresado.
+5. Desplazarse hasta el final de la lista o ejecutar la acción de “cargar más” y comprobar que se emite una segunda petición con `page=2`.
+6. Repetir el paso anterior hasta que la API devuelva `totalPages` igual al número de página solicitado y verificar que ya no se realizan peticiones adicionales.
+
+## Resultado esperado
+- Cada carga incremental agrega nuevos socios al listado sin duplicados.
+- El frontend detiene las solicitudes cuando `hasNextPage` es `false`.
+- No se registran errores en la consola ni respuestas `4xx/5xx` en las peticiones revisadas.


### PR DESCRIPTION
## Summary
- update the socios disponibles infinite hook to use the temporadas socios-disponibles endpoint and DTO shape
- surface pagination metadata aligned with the backend response
- document manual verification steps for incremental loading in the frontend

## Testing
- pnpm lint *(fails: command enters interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68d97def256c8324a9c1006ba80f8582